### PR TITLE
make sure base64ct has Encoding::encode_string

### DIFF
--- a/rustyguard-tun/Cargo.toml
+++ b/rustyguard-tun/Cargo.toml
@@ -11,7 +11,7 @@ rustyguard-types = { version = "0.1", path = "../rustyguard-types" }
 
 rand = "0.8"
 tai64 = "4.0"
-base64ct = "1"
+base64ct = { version = "1.6", features = ["alloc"] }
 tun = { version = "0.6", features = ["async"], git = "https://github.com/conradludgate/rust-tun" }
 tokio = { version = "1", features = ["full"] }
 knuffel = { version = "3.2.0" }


### PR DESCRIPTION
It is guarded by the `alloc` feature.