### PR TITLE
ip rate limiting: allow user parameterization

### DIFF
--- a/rustyguard-utils/src/rate_limiter.rs
+++ b/rustyguard-utils/src/rate_limiter.rs
@@ -7,6 +7,26 @@ use rand_core::RngCore;
 extern crate alloc;
 use alloc::vec::Vec;
 
+pub struct RateLimitParams {
+    pub delta: f64,
+    pub epsilon: f64,
+}
+impl RateLimitParams {
+    pub const STRONG: Self = Self {
+        delta: 0.01,
+        epsilon: 10.0 / 20_000.0,
+    };
+    pub const WEAK: Self = Self {
+        delta: 0.05,
+        epsilon: 100.0 / 20_000.0,
+    };
+}
+impl Default for RateLimitParams {
+    fn default() -> Self {
+        Self::STRONG
+    }
+}
+
 /// CountMinSketch is a fast, O(1) memory way to measure number of times we see a client
 /// over time.
 ///


### PR DESCRIPTION
I thought I would create a type to house some default profiles. I'm not a mathematician, so you may want to change the profile names or remove them entirely. If we remove them, I would probably remove the type and just have two f64s in Config directly.