### PR TITLE
fix: macos packet af header

### DIFF
--- a/rustyguard-core/src/time.rs
+++ b/rustyguard-core/src/time.rs
@@ -41,7 +41,7 @@ pub(crate) enum TimerEntryType {
 
 pub(crate) fn tick_timers(sessions: &Sessions) -> Option<MaintenanceMsg> {
     let mut state_ref = sessions.dynamic.borrow_mut();
-    let state = &mut *state_ref;
+    let mut state = &mut *state_ref;
 
     while state.timers.peek().is_some_and(|t| t.time < state.now) {
         let entry = state.timers.pop().unwrap().kind;
@@ -65,6 +65,9 @@ pub(crate) fn tick_timers(sessions: &Sessions) -> Option<MaintenanceMsg> {
 
                 if should_reinit {
                     let socket = peer.endpoint.expect("a rekey event should not be scheduled if we've never seen this endpoint before");
+                    // Must drop the borrow before calling new_handshake,
+                    // which needs its own mutable borrow of dynamic.
+                    drop(state_ref);
                     // if this errors, it's due to a key-exchange error (diffie-hellman produced all zeros).
                     // nothign we can really do about that.
                     if let Ok(hs) = new_handshake(sessions, peer_idx) {
@@ -73,6 +76,9 @@ pub(crate) fn tick_timers(sessions: &Sessions) -> Option<MaintenanceMsg> {
                             data: MaintenanceRepr::Init(hs),
                         });
                     }
+                    // Re-borrow for the next loop iteration
+                    state_ref = sessions.dynamic.borrow_mut();
+                    state = &mut *state_ref;
                 }
             }
             TimerEntryType::ExpireTransport { session_id } => {

--- a/rustyguard-tun/src/lib.rs
+++ b/rustyguard-tun/src/lib.rs
@@ -7,9 +7,16 @@ use rand::{rngs::OsRng, Rng, TryRngCore};
 use rustyguard_core::{Config, DataHeader, Message, PeerId, PublicKey, Sessions, StaticPrivateKey};
 use rustyguard_crypto::StaticPeerConfig;
 
+use crate::tun::{platform, Device as _, KERNEL_HEADER_LEN};
+
 pub mod tun;
 
-pub const H: usize = std::mem::size_of::<DataHeader>();
+/// Starting buffer position of the IP packet after all headers
+/// defined as `max(size_of::<DataHeader>(), KERNEL_HEADER_LEN)`
+const IP_PACKET_START: usize = const_max(std::mem::size_of::<DataHeader>(), KERNEL_HEADER_LEN);
+
+/// Starting buffer position where the TUN must be read
+pub const TUN_BUF_START: usize = IP_PACKET_START - KERNEL_HEADER_LEN;
 
 /// 16-byte aligned packet of 2048 bytes.
 /// MTU is assumed to be in the range of 1500 or so, so 2048 should be sufficient.
@@ -180,11 +187,24 @@ pub fn handle_extern<'a>(
                 return Write::None;
             }
 
-            return Write::Inbound(buf);
+            let len_data = buf.len();
+            // recv_message wrote the decrypted packet for the TUN
+            // of len_data bytes starting at IP_PACKET_START
+            // we prepend the kernel header before it if needed
+            let tun_buf = &mut ep_buf[TUN_BUF_START..IP_PACKET_START + len_data];
+            let (header, packet) = tun_buf
+                .split_first_chunk_mut()
+                .expect("Enough len for header by definition of TUN_BUF_START");
+            *header = platform::Device::get_header_for(packet);
+
+            // and return KERNEL_HEADER || IP_PACKET for the TUN
+            return Write::Inbound(tun_buf);
         }
+
         Ok(Message::Write(buf)) => {
+            let len_data = buf.len();
             // println!("sending: {buf:?}");
-            return Write::Outbound(buf, addr);
+            return Write::Outbound(&mut ep_buf[..len_data], addr);
         }
     }
 
@@ -197,8 +217,8 @@ pub fn handle_intern<'a>(
     reply_buf: &'a mut [u8],
     filled: usize,
 ) -> Write<'a> {
-    let tun_buf = &mut reply_buf[H..filled];
-    let n = filled - H;
+    let tun_buf = &mut reply_buf[IP_PACKET_START..filled];
+    let n = filled - IP_PACKET_START;
 
     // println!("tun->wg {:02X?}", tun_buf.filled());
     let Ok(ipv4) = packet::ip::v4::Packet::new(tun_buf) else {
@@ -214,11 +234,11 @@ pub fn handle_intern<'a>(
         return Write::None;
     }
 
-    let pad_to = H + n.next_multiple_of(16);
+    let pad_to = IP_PACKET_START + n.next_multiple_of(16);
     reply_buf[filled..pad_to].fill(0);
 
     match sessions
-        .send_message(*peer_idx, &mut reply_buf[H..pad_to])
+        .send_message(*peer_idx, &mut reply_buf[IP_PACKET_START..pad_to])
         .unwrap()
     {
         rustyguard_core::SendMessage::Maintenance(msg) => {
@@ -227,9 +247,26 @@ pub fn handle_intern<'a>(
             Write::Outbound(&reply_buf[..data.len()], msg.to())
         }
         rustyguard_core::SendMessage::Data(ep, metadata) => {
-            let buf = &mut reply_buf[..pad_to + 16];
+            /// Size of the WireGuard tag
+            const TAG_FOOTER_SIZE: usize = 16;
+
+            /// Starting position of the WireGuard packet to send to a peer
+            const WG_PACKET_START: usize = IP_PACKET_START - std::mem::size_of::<DataHeader>();
+            // send_message wrote the cypher text at [IP_PACKET_START..pad_to]
+            // so the header place is [WG_PACKET_START..IP_PACKET_START]
+            // and the footer [pad_to..pad_to + TAG_FOOTER_SIZE].
+            let buf = &mut reply_buf[WG_PACKET_START..pad_to + TAG_FOOTER_SIZE];
             metadata.frame_in_place(buf);
             Write::Outbound(buf, ep)
         }
+    }
+}
+
+/// TODO: replace by max once const stable
+const fn const_max(a: usize, b: usize) -> usize {
+    if a <= b {
+        b
+    } else {
+        a
     }
 }

--- a/rustyguard-tun/src/main.rs
+++ b/rustyguard-tun/src/main.rs
@@ -1,5 +1,7 @@
 use rand::{rngs::OsRng, TryRngCore};
-use rustyguard_tun::{handle_extern, handle_intern, tun, AlignedPacket, TunConfig, Write, H};
+use rustyguard_tun::{
+    handle_extern, handle_intern, tun, AlignedPacket, TunConfig, Write, TUN_BUF_START,
+};
 use tai64::Tai64N;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt, ReadBuf},
@@ -27,7 +29,7 @@ async fn main() {
     let mut tick = tokio::time::interval(std::time::Duration::from_secs(1));
     loop {
         let mut ep_buf = ReadBuf::new(&mut buf.0);
-        let mut tun_buf = ReadBuf::new(&mut reply_buf[H..]);
+        let mut tun_buf = ReadBuf::new(&mut reply_buf[TUN_BUF_START..]);
         let write = tokio::select! {
             _ = tick.tick() => {
                 while let Some(msg) = sessions.turn(Tai64N::now(), &mut OsRng.unwrap_err()) {
@@ -43,7 +45,7 @@ async fn main() {
             }
             res = dev.read_buf(&mut tun_buf) => {
                 let n = res.unwrap();
-                handle_intern(&mut sessions, &peer_net, &mut reply_buf, H + n)
+                handle_intern(&mut sessions, &peer_net, &mut reply_buf, TUN_BUF_START + n)
             }
         };
 

--- a/rustyguard-tun/src/tun/async/device.rs
+++ b/rustyguard-tun/src/tun/async/device.rs
@@ -8,7 +8,7 @@ use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::tun::platform::posix::Fd;
-use crate::tun::platform::Device;
+use crate::tun::platform::{Device, Queue};
 
 /// An async TUN device wrapper around a TUN device.
 pub struct AsyncDevice {
@@ -54,7 +54,7 @@ impl AsyncWrite for AsyncDevice {
     ) -> Poll<io::Result<usize>> {
         loop {
             let mut guard = ready!(self.inner.poll_write_ready_mut(cx))?;
-            match guard.try_io(|inner| inner.get_mut().write(buf)) {
+            match guard.try_io(|inner| Queue::write_fd(inner.get_mut(), buf)) {
                 Ok(res) => return Poll::Ready(res),
                 Err(_wb) => continue,
             }

--- a/rustyguard-tun/src/tun/configuration.rs
+++ b/rustyguard-tun/src/tun/configuration.rs
@@ -29,6 +29,12 @@ impl Configuration {
         self
     }
 
+    /// Set MTU
+    pub fn mtu(&mut self, value: i32) -> &mut Self {
+        self.mtu = Some(value);
+        self
+    }
+
     /// Set the interface to be enabled once created.
     pub fn up(&mut self) -> &mut Self {
         self.enabled = Some(true);

--- a/rustyguard-tun/src/tun/device.rs
+++ b/rustyguard-tun/src/tun/device.rs
@@ -5,8 +5,14 @@ use super::configuration::Configuration;
 use super::error::*;
 
 /// A TUN device.
-pub trait Device: Read + Write {
+pub trait Device<const HEADER_LEN: usize>: Read + Write {
     type Queue: Read + Write;
+
+    /// Header prepended/to prepend for given packet to read/write to tun
+    fn get_header_for(ip_pkt: &[u8]) -> [u8; HEADER_LEN];
+
+    /// The OS-assigned interface name (e.g. `"wg0"`, `"utun3"`).
+    fn name(&self) -> &str;
 
     /// Reconfigure the device.
     fn configure(&mut self, config: &Configuration) -> Result<()> {

--- a/rustyguard-tun/src/tun/mod.rs
+++ b/rustyguard-tun/src/tun/mod.rs
@@ -5,13 +5,14 @@ mod address;
 // pub use address::IntoAddress;
 
 mod device;
-// pub use device::Device;
+pub use device::Device;
 
 mod configuration;
 pub use configuration::Configuration;
 
 pub mod platform;
 // pub use platform::create;
+pub use platform::KERNEL_HEADER_LEN;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod r#async;

--- a/rustyguard-tun/src/tun/platform/linux/device.rs
+++ b/rustyguard-tun/src/tun/platform/linux/device.rs
@@ -167,9 +167,19 @@ impl Write for Device {
         self.queues[0].write_vectored(bufs)
     }
 }
+/// Is 0 in Linux, used for other platform
+pub const KERNEL_HEADER_LEN: usize = 0;
 
-impl D for Device {
+impl D<KERNEL_HEADER_LEN> for Device {
     type Queue = Queue;
+
+    fn get_header_for(ip_pkt: &[u8]) -> [u8; KERNEL_HEADER_LEN] {
+        []
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 
     fn enabled(&mut self, value: bool) -> Result<()> {
         unsafe {
@@ -266,6 +276,14 @@ pub struct Queue {
 impl Queue {
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
+    }
+
+    pub(crate) fn write_fd(fd: &mut Fd, buf: &[u8]) -> io::Result<usize> {
+        fd.write(buf)
+    }
+
+    pub(crate) fn write_fd_vectored(fd: &mut Fd, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        fd.write_vectored(bufs)
     }
 }
 

--- a/rustyguard-tun/src/tun/platform/linux/mod.rs
+++ b/rustyguard-tun/src/tun/platform/linux/mod.rs
@@ -3,7 +3,7 @@
 pub mod sys;
 
 mod device;
-pub use self::device::{Device, Queue};
+pub use self::device::{Device, Queue, KERNEL_HEADER_LEN};
 
 use crate::tun::configuration::Configuration as C;
 use crate::tun::error::*;

--- a/rustyguard-tun/src/tun/platform/macos/device.rs
+++ b/rustyguard-tun/src/tun/platform/macos/device.rs
@@ -24,7 +24,7 @@ use std::{
 
 /// A TUN device using the TUN macOS driver.
 pub struct Device {
-    pub(crate) name: String,
+    name: String,
     pub(crate) queue: Queue,
     pub(crate) ctl: Fd,
 }
@@ -162,20 +162,40 @@ impl Read for Device {
 
 impl Write for Device {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.queue.tun.write(buf)
+        self.queue.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.queue.tun.flush()
+        self.queue.flush()
     }
 
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-        self.queue.tun.write_vectored(bufs)
+        self.queue.write_vectored(bufs)
     }
 }
 
-impl D for Device {
+/// macOS TUN prepends a header of this size to any packet.
+pub const KERNEL_HEADER_LEN: usize = 4;
+const KERNEL_HEADER_V4: [u8; KERNEL_HEADER_LEN] = (libc::AF_INET as u32).to_be_bytes();
+const KERNEL_HEADER_V6: [u8; KERNEL_HEADER_LEN] = (libc::AF_INET6 as u32).to_be_bytes();
+
+impl D<KERNEL_HEADER_LEN> for Device {
     type Queue = Queue;
+
+    /// macOS TUN requires prepending the returned header before sending the given packet.
+    ///
+    /// Panic if ip_pkt is not an IP packet.
+    fn get_header_for(ip_pkt: &[u8]) -> [u8; KERNEL_HEADER_LEN] {
+        match ip_pkt[0] >> 4 {
+            4 => KERNEL_HEADER_V4,
+            6 => KERNEL_HEADER_V6,
+            _ => panic!("Invalid IP packet"),
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 
     fn enabled(&mut self, value: bool) -> Result<()> {
         unsafe {
@@ -271,6 +291,34 @@ impl Queue {
     pub fn set_nonblock(&self) -> io::Result<()> {
         self.tun.set_nonblock()
     }
+
+    pub(crate) fn write_fd(fd: &mut Fd, buf: &[u8]) -> io::Result<usize> {
+        assert_af_header(buf.first_chunk().unwrap_or(&[0; _]))?;
+
+        fd.write(buf)
+    }
+
+    pub(crate) fn write_fd_vectored(fd: &mut Fd, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        let mut af_check = [0; 5];
+        af_check.as_mut_slice().write_vectored(bufs)?;
+        assert_af_header(&af_check)?;
+
+        fd.write_vectored(bufs)
+    }
+}
+
+/// Check that the first chunk of a packet to write has the correct AF_INET header
+fn assert_af_header(chunk: &[u8; 5]) -> io::Result<()> {
+    let [chunk @ .., version_byte] = chunk;
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        match (version_byte >> 4, chunk) {
+        (4, &KERNEL_HEADER_V4) | (6, &KERNEL_HEADER_V6) => return Ok(()),
+        (4, _) => "The IPv4 packet must start with libc::AF_INET header to be written to the TUN on macOS",
+        (6, _) => "The IPv6 packet must start with libc::AF_INET6 header to be written to the TUN on macOS",
+        _ => "Unable to recognize the IP version of the packet, on macOS target it must start with the
+        AF_INET(6) header depending on IP version, use Device trait method get_header_for",
+    }))
 }
 
 impl AsRawFd for Queue {
@@ -297,7 +345,7 @@ impl Read for Queue {
 
 impl Write for Queue {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.tun.write(buf)
+        Self::write_fd(&mut self.tun, buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -305,6 +353,6 @@ impl Write for Queue {
     }
 
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-        self.tun.write_vectored(bufs)
+        Self::write_fd_vectored(&mut self.tun, bufs)
     }
 }

--- a/rustyguard-tun/src/tun/platform/macos/mod.rs
+++ b/rustyguard-tun/src/tun/platform/macos/mod.rs
@@ -3,7 +3,7 @@
 pub mod sys;
 
 mod device;
-pub use self::device::{Device, Queue};
+pub use self::device::{Device, Queue, KERNEL_HEADER_LEN};
 
 use crate::tun::configuration::Configuration as C;
 use crate::tun::error::*;

--- a/rustyguard-tun/src/tun/platform/mod.rs
+++ b/rustyguard-tun/src/tun/platform/mod.rs
@@ -6,9 +6,9 @@ pub mod posix;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "linux")]
-pub use self::linux::{create, Device, Queue};
+pub use self::linux::{create, Device, Queue, KERNEL_HEADER_LEN};
 
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "macos")]
-pub use self::macos::{create, Device, Queue};
+pub use self::macos::{create, Device, Queue, KERNEL_HEADER_LEN};


### PR DESCRIPTION
This is my attempt to fix issue raised [here](https://github.com/conradludgate/rustyguard/pull/9#issuecomment-4406794498).

It also adds a getter for TUN interface name and a configuration setter for MTU.

The issue is that macOS' TUN requires that writing to it starts with an `libc::AF_INET(6)` header in big endian depending on the IP version, and reading from it add this header which must be removed. The main difficulty is that the `Write/AsyncWrite` traits do not allow to modify the input slices to write (especially vectored version) and we must also take into account to remove the header when we read the TUN.

The approach I took was to keep having no allocation on the hot path so instead of trying to add the header (which requires allocating a `Vec` with first slice being the header, copy input slices after and write the result in vectored case), the traits implementations reject with an `io::Error:InvalidInput` when attempting to write a packet without the correct header.

So the trait caller is responsible for adding the header at the beginning of the packet, this is done by introducing const to `Device` which indicate length of a potential header to handle reading and a `get_af_header` function which returns the header to write for a given IP packet. Then the handle_* methods in `tun/lib.rs` account for it and only the buffer offset to read the tun is visible publicly and used in `tun/main.rs`.

I tried to make it so that adding more platform is easy, even if the header for the new platform is bigger than the WireGuard packet's header.

Let me know if you have a better approach.