### PR TITLE
test(e2e): add macos guest support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace --all-targets
+      - run: cargo test --workspace

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,64 @@
+name: e2e
+
+# Lima-based VM tests. Only run on push to main or PRs labeled `e2e`,
+# since the suite takes a few minutes per run.
+#
+# The macOS guest path is not exercised here: GitHub-hosted macOS runners
+# don't support nested virtualization, so Apple's Virtualization.framework
+# refuses to start (VZErrorDomain Code=2). Run `pytest --rg-os=darwin`
+# locally on an Apple Silicon host instead.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LIMA_VERSION: "2.1.1"
+
+jobs:
+  linux-guest:
+    name: lima + ubuntu guest
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: astral-sh/setup-uv@v6
+      - name: Install QEMU + Lima
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils ovmf
+          curl -fsSL "https://github.com/lima-vm/lima/releases/download/v${LIMA_VERSION}/lima-${LIMA_VERSION}-Linux-x86_64.tar.gz" \
+            | sudo tar -xz -C /usr/local
+          # Lima needs the running user to access /dev/kvm without sudo.
+          sudo chmod 666 /dev/kvm || true
+          ls -la /dev/kvm || true
+          limactl --version
+          qemu-system-x86_64 --version | head -1
+      - name: Run pytest
+        working-directory: tests/e2e
+        run: uv run pytest -v --vm-backend=lima --rg-os=linux
+      - name: Dump lima logs on failure
+        if: failure()
+        run: |
+          for d in ~/.lima/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            for f in "$d"ha.stderr.log "$d"ha.stdout.log "$d"serial.log "$d"qemu.log; do
+              [ -f "$f" ] && echo "----- $f -----" && cat "$f"
+            done
+          done
+      - name: Cleanup VMs
+        if: always()
+        working-directory: tests/e2e
+        run: uv run python -m rustyguard_e2e.cli clean --backend=lima

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,7 +1,11 @@
 # rustyguard end-to-end tests
 
-VM-based ping/handshake suite that runs the kernel WireGuard implementation
-against `rustyguard-tun` across two Linux VMs.
+VM-based suite that runs the kernel WireGuard implementation against
+`rustyguard-tun` across two VMs and exercises the resulting tunnel.
+
+The default run covers handshake completion, bidirectional ICMP, near-MTU
+ping flood, iperf3 TCP throughput and UDP loss/jitter, and `wg show transfer`
+counter sanity. A multi-minute rekey soak is available under `--run-slow`.
 
 ## Quick start
 
@@ -32,6 +36,8 @@ Colima users: install `lima` directly and use the `lima` backend.
 - `--keep-vms` - leave VMs running after the suite for debugging.
 - `--rg-os=darwin` - run the rustyguard peer in a macOS guest (lima backend only,
   Apple Silicon host required, ~14 GB IPSW download on first use).
+- `--run-slow` - include `@pytest.mark.slow` tests (currently the ~150s rekey
+  soak in `tests/test_soak.py`).
 - `pytest -k <pattern>` - select a subset of tests.
 
 ## CI

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -30,7 +30,20 @@ Colima users: install `lima` directly and use the `lima` backend.
 ## Useful flags
 
 - `--keep-vms` - leave VMs running after the suite for debugging.
+- `--rg-os=darwin` - run the rustyguard peer in a macOS guest (lima backend only,
+  Apple Silicon host required, ~14 GB IPSW download on first use).
 - `pytest -k <pattern>` - select a subset of tests.
+
+## CI
+
+This suite does not run on every PR. Trigger the linux-guest job by adding the
+`e2e` label to a PR, or by pushing to `main`.
+
+macOS guest tests (`--rg-os=darwin`) are not run in CI. GitHub-hosted macOS
+runners don't expose Apple's Virtualization framework to user code, so
+`limactl start template:macos` fails with
+`VZErrorDomain Code=2 "Virtualization is not available on this hardware."`.
+Run them locally on an Apple Silicon Mac instead.
 
 ## Cleanup
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -74,7 +74,8 @@ def peers(
     provider.create(RG_VM, os=rg_os)
 
     try:
-        provider.install_packages(WG_VM, "wireguard")
+        provider.install_packages(WG_VM, "wireguard", "iperf3")
+        provider.install_packages(RG_VM, "iperf3")
 
         binary = build.build(provider.target_triple(rg_os))
         rg_binary_path = "/tmp/rustyguard-tun"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -44,6 +44,29 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Skip VM teardown so failures can be inspected.",
     )
+    group.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="Include tests marked @pytest.mark.slow (e.g. multi-minute soaks).",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers", "slow: tests that take >1 minute; opt in with --run-slow"
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if config.getoption("--run-slow"):
+        return
+    skip_slow = pytest.mark.skip(reason="requires --run-slow")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 import pytest
 
 from rustyguard_e2e import build, config, registry
-from rustyguard_e2e.provider import Peer, Provider
+from rustyguard_e2e.provider import GuestOS, Peer, Provider
 
 
 WG_VM = "wg-kernel"
@@ -29,6 +29,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="VM backend to use. 'auto' picks the first available on PATH.",
     )
     group.addoption(
+        "--rg-os",
+        action="store",
+        default=os.environ.get("RG_OS", "linux"),
+        choices=("linux", "darwin"),
+        help=(
+            "Guest OS for the rustyguard peer. 'darwin' requires the lima backend "
+            "and an Apple Silicon macOS host."
+        ),
+    )
+    group.addoption(
         "--keep-vms",
         action="store_true",
         default=False,
@@ -43,21 +53,33 @@ def provider(request: pytest.FixtureRequest) -> Provider:
 
 
 @pytest.fixture(scope="session")
+def rg_os(request: pytest.FixtureRequest, provider: Provider) -> GuestOS:
+    requested: GuestOS = request.config.getoption("--rg-os")
+    if requested not in provider.supported_guest_os():
+        pytest.skip(
+            f"backend {provider.name!r} cannot run {requested!r} guests on this host"
+        )
+    return requested
+
+
+@pytest.fixture(scope="session")
 def peers(
     request: pytest.FixtureRequest,
     provider: Provider,
+    rg_os: GuestOS,
 ) -> Iterator[tuple[Peer, Peer]]:
     keep = request.config.getoption("--keep-vms")
 
-    provider.create(WG_VM)
-    provider.create(RG_VM)
+    provider.create(WG_VM, os="linux")
+    provider.create(RG_VM, os=rg_os)
 
     try:
         provider.install_packages(WG_VM, "wireguard")
 
-        binary = build.build(provider.target_triple)
-        provider.copy_in(RG_VM, binary, "/tmp/rustyguard-tun")
-        provider.exec(RG_VM, ["chmod", "+x", "/tmp/rustyguard-tun"], root=True)
+        binary = build.build(provider.target_triple(rg_os))
+        rg_binary_path = "/tmp/rustyguard-tun"
+        provider.copy_in(RG_VM, binary, rg_binary_path)
+        provider.exec(RG_VM, ["chmod", "+x", rg_binary_path], root=True)
 
         wg_addr = provider.address(WG_VM)
         rg_addr = provider.address(RG_VM)
@@ -70,12 +92,12 @@ def peers(
         with tempfile.TemporaryDirectory() as tmp:
             wg_path, rg_path = config.write_to(pathlib.Path(tmp), cfg)
             _bring_up_kernel_peer(provider, wg_path)
-            _bring_up_rustyguard_peer(provider, rg_path)
+            _bring_up_rustyguard_peer(provider, rg_path, rg_os)
 
         # Allow the handshake to complete before returning.
         _wait_for_handshake(provider, WG_VM)
 
-        yield Peer(WG_VM, wg_addr), Peer(RG_VM, rg_addr)
+        yield Peer(WG_VM, wg_addr, "linux"), Peer(RG_VM, rg_addr, rg_os)
     finally:
         if not keep:
             _teardown(provider)
@@ -89,35 +111,96 @@ def _bring_up_kernel_peer(provider: Provider, wg_conf: pathlib.Path) -> None:
     provider.exec(WG_VM, ["wg-quick", "up", "wg0"], root=True)
 
 
-def _bring_up_rustyguard_peer(provider: Provider, rg_conf: pathlib.Path) -> None:
+def _bring_up_rustyguard_peer(
+    provider: Provider, rg_conf: pathlib.Path, rg_os: GuestOS
+) -> None:
     provider.copy_in(RG_VM, rg_conf, "/tmp/rg.conf")
-    # Detach with systemd-run so the binary survives the exec connection.
+    if rg_os == "linux":
+        # Detach with systemd-run so the binary survives the exec connection.
+        provider.exec(
+            RG_VM,
+            [
+                "systemd-run",
+                "--unit=rustyguard-tun",
+                "--quiet",
+                "--",
+                "/tmp/rustyguard-tun",
+                "/tmp/rg.conf",
+            ],
+            root=True,
+        )
+    else:
+        # macOS guest: launchd would be overkill; nohup the binary and route
+        # its output into /tmp so we can read it back if something fails.
+        provider.exec(
+            RG_VM,
+            [
+                "sh",
+                "-c",
+                "nohup /tmp/rustyguard-tun /tmp/rg.conf "
+                ">/tmp/rustyguard-tun.log 2>&1 &",
+            ],
+            root=True,
+        )
+    _wait_for_tun_device(provider, RG_VM, rg_os)
+    if rg_os == "darwin":
+        _install_darwin_allowed_ips_route(provider, RG_VM)
+
+
+def _install_darwin_allowed_ips_route(provider: Provider, vm: str) -> None:
+    """Install a /sbin/route entry for the WG peer on macOS.
+
+    rustyguard-tun on macOS does not auto-install routes for AllowedIPs, so
+    without this step the kernel has no path back through utun for replies.
+    """
+    iface = _find_utun_for_addr(provider, vm, config.RG_TUN_ADDR)
     provider.exec(
-        RG_VM,
+        vm,
         [
-            "systemd-run",
-            "--unit=rustyguard-tun",
-            "--quiet",
-            "--",
-            "/tmp/rustyguard-tun",
-            "/tmp/rg.conf",
+            "/sbin/route",
+            "-n",
+            "add",
+            "-inet",
+            f"{config.WG_TUN_ADDR}/32",
+            "-interface",
+            iface,
         ],
         root=True,
     )
-    _wait_for_tun_device(provider, RG_VM)
 
 
-def _wait_for_tun_device(provider: Provider, vm: str, *, timeout: float = 10.0) -> None:
+def _find_utun_for_addr(provider: Provider, vm: str, addr: str) -> str:
+    """Return the utun interface whose `inet` matches `addr`."""
+    result = provider.exec(vm, ["ifconfig"], capture=True)
+    current: str | None = None
+    needle = f"inet {addr} "
+    for line in (result.stdout or "").splitlines():
+        if line and not line.startswith((" ", "\t")):
+            current = line.split(":", 1)[0]
+        elif current and current.startswith("utun") and needle in line:
+            return current
+    raise RuntimeError(f"no utun on {vm!r} has inet {addr}")
+
+
+def _wait_for_tun_device(
+    provider: Provider, vm: str, vm_os: GuestOS, *, timeout: float = 15.0
+) -> None:
     deadline = time.monotonic() + timeout
+    if vm_os == "linux":
+        cmd = ["ip", "-br", "link", "show"]
+        needle = "tun"
+    else:
+        cmd = ["ifconfig", "-l"]
+        needle = "utun"
     while time.monotonic() < deadline:
         result = provider.exec(
             vm,
-            ["ip", "-br", "link", "show"],
+            cmd,
             root=True,
             check=False,
             capture=True,
         )
-        if "tun" in (result.stdout or ""):
+        if needle in (result.stdout or ""):
             return
         time.sleep(0.5)
     raise RuntimeError(f"timed out waiting for tun device on {vm!r}")

--- a/tests/e2e/rustyguard_e2e/build.py
+++ b/tests/e2e/rustyguard_e2e/build.py
@@ -1,7 +1,8 @@
 """Build the rustyguard-tun binary for the target VM.
 
-Uses `cross` for cross-architecture builds; falls back to plain `cargo`
-when the host arch matches the VM and `cross` is not available.
+Linux targets use `cross` for cross-architecture builds (falling back to
+`cargo` when the host arch matches). Darwin targets use plain `cargo`
+since `cross` doesn't support darwin-on-darwin.
 """
 
 from __future__ import annotations
@@ -18,22 +19,30 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 def _host_target_triple() -> str | None:
     machine = platform.machine().lower()
     system = platform.system().lower()
-    if system != "linux":
-        return None
+    arch = None
     if machine in ("arm64", "aarch64"):
-        return "aarch64-unknown-linux-gnu"
-    if machine in ("x86_64", "amd64"):
-        return "x86_64-unknown-linux-gnu"
+        arch = "aarch64"
+    elif machine in ("x86_64", "amd64"):
+        arch = "x86_64"
+    if arch is None:
+        return None
+    if system == "linux":
+        return f"{arch}-unknown-linux-gnu"
+    if system == "darwin":
+        return f"{arch}-apple-darwin"
     return None
 
 
 def build(target_triple: str, *, repo_root: pathlib.Path = REPO_ROOT) -> pathlib.Path:
     """Build rustyguard-tun for `target_triple` and return the binary path."""
 
-    use_cross = shutil.which("cross") is not None and target_triple != _host_target_triple()
-    cmd = (
-        ["cross"] if use_cross else ["cargo"]
-    ) + [
+    is_darwin_target = target_triple.endswith("-apple-darwin")
+    use_cross = (
+        not is_darwin_target
+        and shutil.which("cross") is not None
+        and target_triple != _host_target_triple()
+    )
+    cmd = (["cross"] if use_cross else ["cargo"]) + [
         "build",
         "--bin",
         "rustyguard-tun",

--- a/tests/e2e/rustyguard_e2e/cli.py
+++ b/tests/e2e/rustyguard_e2e/cli.py
@@ -37,7 +37,9 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         return 1
     print("available backends:")
     for name in available:
-        print(f"  - {name}")
+        provider = registry.select(name)
+        guest_os = ", ".join(provider.supported_guest_os())
+        print(f"  - {name}  (guests: {guest_os})")
     return 0
 
 

--- a/tests/e2e/rustyguard_e2e/iperf.py
+++ b/tests/e2e/rustyguard_e2e/iperf.py
@@ -1,0 +1,67 @@
+"""iperf3 driver helpers shared by the throughput tests.
+
+The helpers shell out to `iperf3` inside the guests via `provider.exec`,
+keeping the test bodies focused on assertions instead of subprocess plumbing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+from collections.abc import Iterator
+
+from .provider import Provider
+
+
+DEFAULT_PORT = 5201
+
+
+@contextlib.contextmanager
+def serve(provider: Provider, vm: str, *, bind: str) -> Iterator[None]:
+    """Run an iperf3 server inside `vm`, bound to `bind`, for one connection.
+
+    `-1` exits the server after the first client finishes, so the only cleanup
+    work on exit is best-effort: if the test crashed before a client connected,
+    `pkill` clears the stranded process.
+    """
+    _kill_iperf(provider, vm)
+    provider.exec(
+        vm,
+        [
+            "sh",
+            "-c",
+            f"nohup iperf3 -s -1 -B {bind} >/tmp/iperf-server.log 2>&1 &",
+        ],
+        root=True,
+    )
+    # iperf3 typically opens the listening socket in <100ms; the client
+    # retries connect for a few seconds anyway, so a tiny sleep is enough.
+    time.sleep(0.5)
+    try:
+        yield
+    finally:
+        _kill_iperf(provider, vm)
+
+
+def run_client(
+    provider: Provider,
+    vm: str,
+    target: str,
+    *,
+    udp: bool = False,
+    bandwidth: str | None = None,
+    duration: int = 10,
+) -> dict:
+    """Run an iperf3 client and return its parsed `--json` output."""
+    cmd = ["iperf3", "-c", target, "--json", "-t", str(duration)]
+    if udp:
+        cmd.append("-u")
+    if bandwidth is not None:
+        cmd += ["-b", bandwidth]
+    result = provider.exec(vm, cmd, root=True, capture=True)
+    return json.loads(result.stdout)
+
+
+def _kill_iperf(provider: Provider, vm: str) -> None:
+    provider.exec(vm, ["pkill", "-f", "iperf3"], root=True, check=False)

--- a/tests/e2e/rustyguard_e2e/provider.py
+++ b/tests/e2e/rustyguard_e2e/provider.py
@@ -4,6 +4,10 @@ Each `Provider` implementation drives a particular VM/container tool
 (orb, lima, multipass, ...). Tests only ever talk to the abstract
 interface defined here, so swapping backends is a matter of selecting
 a different implementation in `registry.py`.
+
+Guest OS may differ from VM to VM (Linux for the kernel-WG peer, optionally
+Darwin for the rustyguard peer), so calls that depend on OS specifics take
+the VM name as input and consult `vm_os()` for the right code path.
 """
 
 from __future__ import annotations
@@ -12,6 +16,10 @@ import abc
 import dataclasses
 import pathlib
 import subprocess
+from typing import Literal
+
+
+GuestOS = Literal["linux", "darwin"]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -20,13 +28,13 @@ class Peer:
 
     name: str
     address: str
+    os: GuestOS = "linux"
 
 
 class Provider(abc.ABC):
     """Drives a concrete VM tool."""
 
     name: str
-    target_triple: str
 
     @classmethod
     @abc.abstractmethod
@@ -34,8 +42,20 @@ class Provider(abc.ABC):
         """True iff this backend's CLI is installed and usable on the host."""
 
     @abc.abstractmethod
-    def create(self, vm: str, *, image: str = "ubuntu:noble") -> None:
+    def supported_guest_os(self) -> tuple[GuestOS, ...]:
+        """Guest OSes this backend can provision on the current host."""
+
+    @abc.abstractmethod
+    def target_triple(self, os: GuestOS) -> str:
+        """Rust target triple for binaries that will run inside a `os` guest."""
+
+    @abc.abstractmethod
+    def create(self, vm: str, *, os: GuestOS = "linux") -> None:
         """Provision a VM. Idempotent: re-creating an existing VM is a no-op."""
+
+    @abc.abstractmethod
+    def vm_os(self, vm: str) -> GuestOS:
+        """Guest OS of a previously-created VM."""
 
     @abc.abstractmethod
     def exec(
@@ -62,7 +82,11 @@ class Provider(abc.ABC):
         """Tear down the VM. Idempotent."""
 
     def install_packages(self, vm: str, *packages: str) -> None:
-        """Default apt-based install path; backends may override."""
+        """Linux-only apt install helper; Darwin guests must override or skip."""
+        if self.vm_os(vm) != "linux":
+            raise NotImplementedError(
+                f"install_packages on non-linux guest {vm!r} not supported"
+            )
         self.exec(vm, ["apt-get", "update", "-qq"], root=True)
         self.exec(
             vm,

--- a/tests/e2e/rustyguard_e2e/provider.py
+++ b/tests/e2e/rustyguard_e2e/provider.py
@@ -82,14 +82,17 @@ class Provider(abc.ABC):
         """Tear down the VM. Idempotent."""
 
     def install_packages(self, vm: str, *packages: str) -> None:
-        """Linux-only apt install helper; Darwin guests must override or skip."""
-        if self.vm_os(vm) != "linux":
-            raise NotImplementedError(
-                f"install_packages on non-linux guest {vm!r} not supported"
+        """Install OS packages inside the guest, dispatching on guest OS."""
+        if self.vm_os(vm) == "linux":
+            self.exec(vm, ["apt-get", "update", "-qq"], root=True)
+            self.exec(
+                vm,
+                ["apt-get", "install", "-y", "-qq", *packages],
+                root=True,
             )
-        self.exec(vm, ["apt-get", "update", "-qq"], root=True)
-        self.exec(
-            vm,
-            ["apt-get", "install", "-y", "-qq", *packages],
-            root=True,
-        )
+            return
+        # Lima's macOS template installs Homebrew at /opt/homebrew for the
+        # default unprivileged guest user. `limactl shell` runs a non-login
+        # shell, so brew is not guaranteed to be on PATH; call it by absolute
+        # path to avoid depending on the shell rc files.
+        self.exec(vm, ["/opt/homebrew/bin/brew", "install", "--quiet", *packages])

--- a/tests/e2e/rustyguard_e2e/providers/lima.py
+++ b/tests/e2e/rustyguard_e2e/providers/lima.py
@@ -1,9 +1,11 @@
 """Lima backend.
 
-Lima isolates VMs from each other on its default user-mode network, so we
-provision instances on the `lima:user-v2` slirp4netns network. Unlike
-`lima:shared`, `user-v2` doesn't need socket_vmnet/sudo - sibling VMs
-talk to each other via virtual L2 segments managed by lima itself.
+Supports both Linux and macOS guests (the latter only on Apple Silicon
+hosts via lima's `template://macos`, which requires Virtualization.framework
+and downloads an IPSW on first use - expect ~14GB and several minutes).
+
+Both guest types are placed on the `lima:user-v2` slirp network so siblings
+can talk to each other without socket_vmnet/sudo on the host.
 """
 
 from __future__ import annotations
@@ -14,20 +16,19 @@ import platform
 import shutil
 import subprocess
 
-from ..provider import Provider
+from ..provider import GuestOS, Provider
 
-# `lima:shared` and `lima:user-v2` use the slirp 192.168.5.0/24 range only
-# for the host-to-guest SSH bridge; a sibling-reachable IP lives on a
-# different interface.
+# `lima:user-v2` uses the slirp 192.168.5.0/24 range for the SSH bridge only;
+# the sibling-reachable IP lives on a separate interface.
 _SLIRP_PREFIX = "192.168.5."
 
 
-def _host_target_triple() -> str:
+def _arch() -> str:
     machine = platform.machine().lower()
     if machine in ("arm64", "aarch64"):
-        return "aarch64-unknown-linux-gnu"
+        return "aarch64"
     if machine in ("x86_64", "amd64"):
-        return "x86_64-unknown-linux-gnu"
+        return "x86_64"
     raise RuntimeError(f"unsupported host arch for lima backend: {machine!r}")
 
 
@@ -35,11 +36,39 @@ class LimaProvider(Provider):
     name = "lima"
 
     def __init__(self) -> None:
-        self.target_triple = _host_target_triple()
+        # Track guest OS per VM; populated by create() and back-filled from
+        # `limactl list` for any pre-existing instances we encounter.
+        self._os_cache: dict[str, GuestOS] = {}
 
     @classmethod
     def is_available(cls) -> bool:
         return shutil.which("limactl") is not None
+
+    def supported_guest_os(self) -> tuple[GuestOS, ...]:
+        # macOS guests are aarch64-only and need a macOS host (Virtualization.framework).
+        if platform.system() == "Darwin" and _arch() == "aarch64":
+            return ("linux", "darwin")
+        return ("linux",)
+
+    def target_triple(self, os: GuestOS) -> str:
+        arch = _arch()
+        if os == "linux":
+            return f"{arch}-unknown-linux-gnu"
+        if os == "darwin":
+            return f"{arch}-apple-darwin"
+        raise NotImplementedError(f"lima cannot run {os!r} guests")
+
+    def vm_os(self, vm: str) -> GuestOS:
+        if vm in self._os_cache:
+            return self._os_cache[vm]
+        info = self._instances().get(vm)
+        if info is None:
+            raise RuntimeError(f"vm {vm!r} not provisioned")
+        # `limactl list --format json` nests guest OS under .config.os.
+        os_str = (info.get("config", {}).get("os") or "linux").lower()
+        guest_os: GuestOS = "darwin" if os_str == "darwin" else "linux"
+        self._os_cache[vm] = guest_os
+        return guest_os
 
     def _instances(self) -> dict[str, dict]:
         # `limactl list --format json` emits one JSON object per line.
@@ -58,14 +87,19 @@ class LimaProvider(Provider):
             out[obj["name"]] = obj
         return out
 
-    def create(self, vm: str, *, image: str = "ubuntu:noble") -> None:
+    def create(self, vm: str, *, os: GuestOS = "linux") -> None:
+        if os not in self.supported_guest_os():
+            raise NotImplementedError(
+                f"lima cannot run {os!r} guests on this host"
+            )
+        self._os_cache[vm] = os
         instances = self._instances()
         if vm in instances:
             if instances[vm].get("status") != "Running":
                 subprocess.run(["limactl", "start", vm], check=True)
-            return
-        subprocess.run(
-            [
+        else:
+            template = "template://ubuntu" if os == "linux" else "template://macos"
+            argv = [
                 "limactl",
                 "start",
                 "--name",
@@ -73,9 +107,51 @@ class LimaProvider(Provider):
                 "--tty=false",
                 "--network",
                 "lima:user-v2",
-                "template://ubuntu",
-            ],
+            ]
+            # macOS template defaults to `video.display=default` (a vz window
+            # pops up at boot). Force headless to match the Linux template.
+            if os == "darwin":
+                argv += ["--set", ".video.display = \"none\""]
+            argv.append(template)
+            subprocess.run(argv, check=True)
+        if os == "darwin":
+            self._enable_passwordless_sudo_darwin(vm)
+
+    def _enable_passwordless_sudo_darwin(self, vm: str) -> None:
+        """Install a NOPASSWD sudoers entry for the default `lima` user.
+
+        Lima's macOS template generates a random first-login password and stores
+        it in the guest's home dir; we use it once to drop a sudoers file so all
+        subsequent `sudo` calls run without prompts.
+        """
+        check = subprocess.run(
+            ["limactl", "shell", vm, "test", "-f", "/etc/sudoers.d/00-lima-nopasswd"],
+        )
+        if check.returncode == 0:
+            return
+        pw = subprocess.run(
+            ["limactl", "shell", vm, "cat", "/Users/lima.guest/password"],
             check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            [
+                "limactl",
+                "shell",
+                vm,
+                "sudo",
+                "-S",
+                "sh",
+                "-c",
+                "echo 'lima ALL=(ALL) NOPASSWD: ALL' "
+                ">/etc/sudoers.d/00-lima-nopasswd "
+                "&& chmod 440 /etc/sudoers.d/00-lima-nopasswd",
+            ],
+            input=pw + "\n",
+            check=True,
+            capture_output=True,
+            text=True,
         )
 
     def exec(
@@ -105,6 +181,11 @@ class LimaProvider(Provider):
         )
 
     def address(self, vm: str) -> str:
+        if self.vm_os(vm) == "darwin":
+            return self._darwin_address(vm)
+        return self._linux_address(vm)
+
+    def _linux_address(self, vm: str) -> str:
         result = self.exec(
             vm,
             ["ip", "-j", "-4", "addr", "show"],
@@ -122,7 +203,29 @@ class LimaProvider(Provider):
             "is the 'lima:user-v2' network configured?"
         )
 
+    def _darwin_address(self, vm: str) -> str:
+        # macOS doesn't ship `ip`; scrape `ifconfig` for the first non-loopback,
+        # non-slirp IPv4 on any utun-less interface.
+        result = self.exec(vm, ["ifconfig"], capture=True)
+        current: str | None = None
+        for line in (result.stdout or "").splitlines():
+            if line and not line.startswith((" ", "\t")):
+                # Lines like `en0: flags=...` start an interface block.
+                current = line.split(":", 1)[0]
+                continue
+            stripped = line.strip()
+            if current in (None, "lo0") or not stripped.startswith("inet "):
+                continue
+            ip = stripped.split()[1]
+            if not ip.startswith(_SLIRP_PREFIX) and not ip.startswith("127."):
+                return ip
+        raise RuntimeError(
+            f"no sibling-reachable IPv4 found in lima darwin vm {vm!r}; "
+            "is the 'lima:user-v2' network configured?"
+        )
+
     def delete(self, vm: str) -> None:
+        self._os_cache.pop(vm, None)
         if vm not in self._instances():
             return
         subprocess.run(["limactl", "delete", "-f", vm], check=True)

--- a/tests/e2e/rustyguard_e2e/providers/multipass.py
+++ b/tests/e2e/rustyguard_e2e/providers/multipass.py
@@ -12,10 +12,10 @@ import platform
 import shutil
 import subprocess
 
-from ..provider import Provider
+from ..provider import GuestOS, Provider
 
 
-def _host_target_triple() -> str:
+def _linux_target_triple() -> str:
     machine = platform.machine().lower()
     if machine in ("arm64", "aarch64"):
         return "aarch64-unknown-linux-gnu"
@@ -27,12 +27,20 @@ def _host_target_triple() -> str:
 class MultipassProvider(Provider):
     name = "multipass"
 
-    def __init__(self) -> None:
-        self.target_triple = _host_target_triple()
-
     @classmethod
     def is_available(cls) -> bool:
         return shutil.which("multipass") is not None
+
+    def supported_guest_os(self) -> tuple[GuestOS, ...]:
+        return ("linux",)
+
+    def target_triple(self, os: GuestOS) -> str:
+        if os != "linux":
+            raise NotImplementedError(f"multipass cannot run {os!r} guests")
+        return _linux_target_triple()
+
+    def vm_os(self, vm: str) -> GuestOS:
+        return "linux"
 
     def _info(self, vm: str) -> dict | None:
         result = subprocess.run(
@@ -45,14 +53,13 @@ class MultipassProvider(Provider):
         data = json.loads(result.stdout or "{}")
         return data.get("info", {}).get(vm)
 
-    def create(self, vm: str, *, image: str = "ubuntu:noble") -> None:
+    def create(self, vm: str, *, os: GuestOS = "linux") -> None:
+        if os != "linux":
+            raise NotImplementedError(f"multipass cannot run {os!r} guests")
         if self._info(vm) is not None:
             return
-        # `image` for multipass is a release alias like "noble"; strip the
-        # ubuntu: prefix used by the orb-style spec.
-        release = image.split(":", 1)[1] if ":" in image else image
         subprocess.run(
-            ["multipass", "launch", release, "--name", vm],
+            ["multipass", "launch", "noble", "--name", vm],
             check=True,
         )
 

--- a/tests/e2e/rustyguard_e2e/providers/orb.py
+++ b/tests/e2e/rustyguard_e2e/providers/orb.py
@@ -11,10 +11,10 @@ import platform
 import shutil
 import subprocess
 
-from ..provider import Provider
+from ..provider import GuestOS, Provider
 
 
-def _host_target_triple() -> str:
+def _linux_target_triple() -> str:
     machine = platform.machine().lower()
     if machine in ("arm64", "aarch64"):
         return "aarch64-unknown-linux-gnu"
@@ -26,12 +26,20 @@ def _host_target_triple() -> str:
 class OrbProvider(Provider):
     name = "orb"
 
-    def __init__(self) -> None:
-        self.target_triple = _host_target_triple()
-
     @classmethod
     def is_available(cls) -> bool:
         return shutil.which("orb") is not None
+
+    def supported_guest_os(self) -> tuple[GuestOS, ...]:
+        return ("linux",)
+
+    def target_triple(self, os: GuestOS) -> str:
+        if os != "linux":
+            raise NotImplementedError(f"orb cannot run {os!r} guests")
+        return _linux_target_triple()
+
+    def vm_os(self, vm: str) -> GuestOS:
+        return "linux"
 
     def _machines(self) -> set[str]:
         result = subprocess.run(
@@ -45,10 +53,12 @@ class OrbProvider(Provider):
         data = json.loads(result.stdout or "[]")
         return {entry["name"] for entry in data}
 
-    def create(self, vm: str, *, image: str = "ubuntu:noble") -> None:
+    def create(self, vm: str, *, os: GuestOS = "linux") -> None:
+        if os != "linux":
+            raise NotImplementedError(f"orb cannot run {os!r} guests")
         if vm in self._machines():
             return
-        subprocess.run(["orb", "create", image, vm], check=True)
+        subprocess.run(["orb", "create", "ubuntu:noble", vm], check=True)
 
     def exec(
         self,

--- a/tests/e2e/tests/test_soak.py
+++ b/tests/e2e/tests/test_soak.py
@@ -1,0 +1,64 @@
+"""Long-running validation that the tunnel survives a WireGuard rekey.
+
+`REKEY_AFTER_TIME` in rustyguard-core is 120s; with continuous traffic the
+sending side re-initiates a handshake at that boundary. This test sends
+~150s of pings across the boundary and asserts (a) no meaningful loss and
+(b) the latest-handshake timestamp advanced, proving the rekey actually
+completed mid-flight.
+
+Marked @pytest.mark.slow so it stays opt-in (`pytest --run-slow`).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from rustyguard_e2e import config
+from rustyguard_e2e.provider import Peer, Provider
+
+
+_PING_LOSS_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%\s*packet\s*loss")
+
+
+@pytest.mark.slow
+def test_rekey_survives_traffic(
+    provider: Provider, peers: tuple[Peer, Peer]
+) -> None:
+    wg, rg = peers
+    t0 = _latest_handshake(provider, wg.name)
+    assert t0 > 0, "fixture should have produced an initial handshake"
+
+    result = provider.exec(
+        rg.name,
+        ["ping", "-c", "150", "-i", "1", "-W", "2", "-q", config.WG_TUN_ADDR],
+        root=True,
+        capture=True,
+    )
+    assert result.returncode == 0, (
+        f"soak ping failed:\n{result.stdout}\n{result.stderr}"
+    )
+    match = _PING_LOSS_RE.search(result.stdout or "")
+    assert match, f"could not parse ping output:\n{result.stdout}"
+    loss_pct = float(match.group(1))
+    assert loss_pct < 1.0, f"soak ping loss {loss_pct}% above 1% threshold"
+
+    t1 = _latest_handshake(provider, wg.name)
+    assert t1 > t0, (
+        f"latest-handshake did not advance during 150s soak "
+        f"(t0={t0}, t1={t1}); rekey did not complete"
+    )
+
+
+def _latest_handshake(provider: Provider, vm: str) -> int:
+    """Return the most recent handshake timestamp (unix seconds) on `vm`."""
+    result = provider.exec(
+        vm, ["wg", "show", "wg0", "latest-handshakes"], root=True, capture=True
+    )
+    best = 0
+    for line in (result.stdout or "").splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            best = max(best, int(parts[1]))
+    return best

--- a/tests/e2e/tests/test_throughput.py
+++ b/tests/e2e/tests/test_throughput.py
@@ -1,0 +1,127 @@
+"""Throughput, loss, and counter sanity over the rustyguard tunnel.
+
+These tests sit a layer above `test_handshake`: instead of just confirming a
+single packet round-trips, they push real volumes of TCP and UDP traffic
+through the tunnel and assert the data path behaved reasonably.
+
+Each test is self-contained (its own iperf3 server, its own counter delta)
+so the suite tolerates reordering or being run with `-k <name>`.
+"""
+
+from __future__ import annotations
+
+import re
+
+from rustyguard_e2e import config, iperf
+from rustyguard_e2e.provider import Peer, Provider
+
+
+_TYPICAL_TCP_MSS = 1448
+_PING_LOSS_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%\s*packet\s*loss")
+
+
+def test_iperf3_tcp(provider: Provider, peers: tuple[Peer, Peer]) -> None:
+    wg, rg = peers
+    with iperf.serve(provider, wg.name, bind=config.WG_TUN_ADDR):
+        result = iperf.run_client(provider, rg.name, config.WG_TUN_ADDR)
+
+    end = result["end"]
+    bytes_received = end["sum_received"]["bytes"]
+    retransmits = end["sum_sent"]["retransmits"]
+    bytes_sent = end["sum_sent"]["bytes"]
+
+    assert bytes_received > 1_000_000, (
+        f"iperf3 TCP only moved {bytes_received} bytes in 10s; tunnel is broken or stalled"
+    )
+    # Crude segment estimate; iperf3 doesn't report TCP packet counts directly.
+    est_segments = max(bytes_sent // _TYPICAL_TCP_MSS, 1)
+    retransmit_ratio = retransmits / est_segments
+    assert retransmit_ratio < 0.05, (
+        f"TCP retransmit ratio {retransmit_ratio:.3%} too high "
+        f"({retransmits} retransmits over ~{est_segments} segments)"
+    )
+
+
+def test_iperf3_udp(provider: Provider, peers: tuple[Peer, Peer]) -> None:
+    wg, rg = peers
+    with iperf.serve(provider, wg.name, bind=config.WG_TUN_ADDR):
+        # 5M is comfortably below what any healthy slirp+QEMU+userspace path
+        # can sustain, so loss should be near zero on a working tunnel.
+        result = iperf.run_client(
+            provider, rg.name, config.WG_TUN_ADDR, udp=True, bandwidth="5M"
+        )
+
+    summary = result["end"]["sum"]
+    loss_pct = summary["lost_percent"]
+    jitter_ms = summary["jitter_ms"]
+
+    assert loss_pct < 1.0, f"UDP loss {loss_pct:.2f}% above 1% threshold"
+    assert jitter_ms < 50.0, f"UDP jitter {jitter_ms:.2f}ms above 50ms threshold"
+
+
+def test_large_packet_ping_loss(
+    provider: Provider, peers: tuple[Peer, Peer]
+) -> None:
+    """Ping with 1200-byte payloads to exercise the data path under load.
+
+    1200 stays safely under the WireGuard tunnel's default 1420 MTU (1500 -
+    ~80 bytes encryption overhead), so we measure the data path under load
+    without conflating with fragmentation behavior.
+    """
+    _, rg = peers
+    result = provider.exec(
+        rg.name,
+        [
+            "ping",
+            "-c", "500",
+            "-i", "0.01",
+            "-W", "2",
+            "-s", "1200",
+            "-q",
+            config.WG_TUN_ADDR,
+        ],
+        root=True,
+        capture=True,
+    )
+    assert result.returncode == 0, (
+        f"ping flood failed:\n{result.stdout}\n{result.stderr}"
+    )
+    match = _PING_LOSS_RE.search(result.stdout or "")
+    assert match, f"could not parse ping output:\n{result.stdout}"
+    loss_pct = float(match.group(1))
+    assert loss_pct < 1.0, f"near-MTU ping loss {loss_pct}% above 1% threshold"
+
+
+def test_transfer_counters_advance(
+    provider: Provider, peers: tuple[Peer, Peer]
+) -> None:
+    """`wg show transfer` rx/tx should grow when traffic flows."""
+    wg, rg = peers
+    before_rx, before_tx = _wg_transfer(provider, wg.name)
+
+    provider.exec(
+        rg.name,
+        ["ping", "-c", "100", "-i", "0.05", "-s", "100", "-q", config.WG_TUN_ADDR],
+        root=True,
+        capture=True,
+    )
+
+    after_rx, after_tx = _wg_transfer(provider, wg.name)
+    delta_rx = after_rx - before_rx
+    delta_tx = after_tx - before_tx
+
+    # 100 pings * 100 bytes * 2 (echo + reply) = ~20kB plus WG overhead, so
+    # 10kB on each direction is a safe floor.
+    assert delta_rx > 10_000, f"wg rx counter only advanced by {delta_rx} bytes"
+    assert delta_tx > 10_000, f"wg tx counter only advanced by {delta_tx} bytes"
+
+
+def _wg_transfer(provider: Provider, vm: str) -> tuple[int, int]:
+    result = provider.exec(
+        vm, ["wg", "show", "wg0", "transfer"], root=True, capture=True
+    )
+    for line in (result.stdout or "").splitlines():
+        parts = line.split()
+        if len(parts) == 3:
+            return int(parts[1]), int(parts[2])
+    raise RuntimeError(f"could not parse wg show transfer output:\n{result.stdout}")


### PR DESCRIPTION
Refactor the Provider interface so every backend declares which guest OSes it can host, what Rust target triple each guest needs, and which OS a given VM is running. Existing orb/multipass adapters stay linux-only; the lima adapter gains a template://macos path (gated on Apple Silicon macos hosts), an ifconfig-based address probe for Darwin guests, a one-shot NOPASSWD sudoers install for the random first-login password the macos template generates, and --set video.display=none so the vz window stays hidden.

conftest grows a --rg-os flag (linux | darwin, default linux) that picks the rustyguard peer's OS. The bring-up path dispatches on it: linux keeps the systemd-run unit, darwin nohups the binary and polls for utun* instead of tun*. build.py learns to skip `cross` for *-apple-darwin targets.